### PR TITLE
Fix background drawing for non-en_US locales

### DIFF
--- a/src/plugingl/pidc.cpp
+++ b/src/plugingl/pidc.cpp
@@ -1937,6 +1937,16 @@ void piDC::DrawText( const wxString &text, wxCoord x, wxCoord y )
 #else
             unsigned int texobj;    
             
+            if(m_textbackgroundcolour.Alpha() != 0) {
+                wxPen p = m_pen;
+                wxBrush b = m_brush;
+                SetPen(*wxTRANSPARENT_PEN);
+                SetBrush(wxBrush(m_textbackgroundcolour));
+                DrawRoundedRectangle(x, y, w, h, 3);
+                SetPen(p);
+                SetBrush(b);
+            }
+            
             glGenTextures(1, &texobj);
             glBindTexture(GL_TEXTURE_2D, texobj);
             


### PR DESCRIPTION
Different drawing logic is used for all the locales but en_US to support accented characters, it was missing the bit drawing the background rectangle.